### PR TITLE
Send file starting with filename

### DIFF
--- a/backend/src/config/upload.ts
+++ b/backend/src/config/upload.ts
@@ -8,7 +8,8 @@ export default {
   storage: multer.diskStorage({
     destination: publicFolder,
     filename(req, file, cb) {
-      const fileName = new Date().getTime() + path.extname(file.originalname);
+      var arquivo = file.originalname;
+      const fileName = arquivo.substring(0, arquivo.lastIndexOf(".")) + '-' + new Date().getTime() + path.extname(file.originalname);
 
       return cb(null, fileName);
     }


### PR DESCRIPTION
This commit makes so that files sent in the frontend starts with filename and then after the epoch timestamp, 
e.g: `invoice-1610863629200.pdf`.

So the person that receives the file can identify what's the file about instead of receiving a file with just numbers 
e.g: `1610863629200.pdf`.