### PR TITLE
Seed para usuário administrador default

### DIFF
--- a/backend/src/database/seeds/20200904070004-create-default-users.ts
+++ b/backend/src/database/seeds/20200904070004-create-default-users.ts
@@ -1,0 +1,25 @@
+import { QueryInterface } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.bulkInsert(
+      "Users",
+      [
+        {
+          name: "Administrador",
+          email: "admin@whaticket.com",
+          passwordHash: "$2a$08$WaEmpmFDD/XkDqorkpQ42eUZozOqRCPkPcTkmHHMyuTGUOkI8dHsq",
+          profile: "admin",
+          tokenVersion: 0,
+          createdAt: new Date(),
+          updatedAt: new Date()
+        }
+      ],
+      {}
+    );
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.bulkDelete("Users", {});
+  }
+};


### PR DESCRIPTION
Para facilitar o acesso ao sistema sem precisar ter que criar o usuário direto no banco, criei um seed que cadastra um usuário administrador. Após acessar o sistema é só editar o perfil como quiser.

Dados de acesso
Usuário: admin@whaticket.com
Senha: admin