### PR TITLE
Fix bug SendWhatsAppMedia mustache body null

### DIFF
--- a/backend/src/services/WbotServices/SendWhatsAppMedia.ts
+++ b/backend/src/services/WbotServices/SendWhatsAppMedia.ts
@@ -19,13 +19,16 @@ const SendWhatsAppMedia = async ({
 }: Request): Promise<WbotMessage> => {
   try {
     const wbot = await GetTicketWbot(ticket);
+    const hasBody = body
+      ? formatBody(body as string, ticket.contact)
+      : undefined;
 
     const newMedia = MessageMedia.fromFilePath(media.path);
     const sentMessage = await wbot.sendMessage(
       `${ticket.contact.number}@${ticket.isGroup ? "g" : "c"}.us`,
       newMedia,
       {
-        caption: formatBody(body as string, ticket.contact),
+        caption: hasBody,
         sendAudioAsVoice: true
       }
     );
@@ -36,6 +39,7 @@ const SendWhatsAppMedia = async ({
 
     return sentMessage;
   } catch (err) {
+    console.log(err);
     throw new AppError("ERR_SENDING_WAPP_MSG");
   }
 };


### PR DESCRIPTION
#347 

O envio de media pelo o front não usa o body, na api, você pode enviar o body(caption) 

Então agora valida, se for null não formata o body, se existir o body, ele formata. usando o mustache