### PR TITLE
Atualizando a biblioteca 'Whatsapp-web.js'

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -39,7 +39,7 @@
     "sequelize-typescript": "^1.1.0",
     "socket.io": "^3.0.5",
     "uuid": "^8.3.2",
-    "whatsapp-web.js": "^1.15.3",
+    "whatsapp-web.js": "^1.15.5",
     "yup": "^0.32.8"
   },
   "devDependencies": {


### PR DESCRIPTION
Atualizando a biblioteca 'Whatsapp-web.js' para a versão '1.15.5', versão onde o erro de falha na exclusão foi resolvido.

Print do erro que estava dando na versão anterior:
![image](https://user-images.githubusercontent.com/34557801/153049711-8deb63b5-d03f-4f76-8d40-621113363fd6.png)
