### PR TITLE
User default whatsapp and multiple tickets per contact

### DIFF
--- a/backend/src/controllers/ApiController.ts
+++ b/backend/src/controllers/ApiController.ts
@@ -24,7 +24,10 @@ interface ContactData {
   number: string;
 }
 
-const createContact = async (newContact: string) => {
+const createContact = async (
+  userId: number,
+  newContact: string
+) => {
   await CheckIsValidContact(newContact);
 
   const validNumber: any = await CheckContactNumber(newContact);
@@ -42,7 +45,7 @@ const createContact = async (newContact: string) => {
 
   const contact = await CreateOrUpdateContactService(contactData);
 
-  const defaultWhatsapp = await GetDefaultWhatsApp();
+  const defaultWhatsapp = await GetDefaultWhatsApp(userId);
 
   const createTicket = await FindOrCreateTicketService(
     contact,
@@ -76,7 +79,8 @@ export const index = async (req: Request, res: Response): Promise<Response> => {
     throw new AppError(err.message);
   }
 
-  const contactAndTicket = await createContact(newContact.number);
+  const userId:number = parseInt(req.user.id);
+  const contactAndTicket = await createContact(userId, newContact.number);
 
   if (medias) {
     await Promise.all(

--- a/backend/src/controllers/ImportPhoneContactsController.ts
+++ b/backend/src/controllers/ImportPhoneContactsController.ts
@@ -2,7 +2,8 @@ import { Request, Response } from "express";
 import ImportContactsService from "../services/WbotServices/ImportContactsService";
 
 export const store = async (req: Request, res: Response): Promise<Response> => {
-  await ImportContactsService();
+  const userId:number = parseInt(req.user.id);
+  await ImportContactsService(userId);
 
   return res.status(200).json({ message: "contacts imported" });
 };

--- a/backend/src/controllers/UserController.ts
+++ b/backend/src/controllers/UserController.ts
@@ -27,7 +27,7 @@ export const index = async (req: Request, res: Response): Promise<Response> => {
 };
 
 export const store = async (req: Request, res: Response): Promise<Response> => {
-  const { email, password, name, profile, queueIds } = req.body;
+  const { email, password, name, profile, queueIds, whatsappId } = req.body;
 
   if (
     req.url === "/signup" &&
@@ -43,7 +43,8 @@ export const store = async (req: Request, res: Response): Promise<Response> => {
     password,
     name,
     profile,
-    queueIds
+    queueIds,
+    whatsappId
   });
 
   const io = getIO();

--- a/backend/src/database/migrations/20220223095932-add-whatsapp-to-user.ts
+++ b/backend/src/database/migrations/20220223095932-add-whatsapp-to-user.ts
@@ -1,0 +1,17 @@
+import { QueryInterface, DataTypes } from "sequelize";
+
+module.exports = {
+  up: (queryInterface: QueryInterface) => {
+    return queryInterface.addColumn("Users", "whatsappId", {
+      type: DataTypes.INTEGER,
+      references: { model: "Whatsapps", key: "id" },
+      onUpdate: "CASCADE",
+      onDelete: "SET NULL",
+      allowNull: true
+    },);
+  },
+
+  down: (queryInterface: QueryInterface) => {
+    return queryInterface.removeColumn("Users", "whatsappId");
+  }
+};

--- a/backend/src/helpers/CheckContactOpenTickets.ts
+++ b/backend/src/helpers/CheckContactOpenTickets.ts
@@ -2,9 +2,12 @@ import { Op } from "sequelize";
 import AppError from "../errors/AppError";
 import Ticket from "../models/Ticket";
 
-const CheckContactOpenTickets = async (contactId: number): Promise<void> => {
+const CheckContactOpenTickets = async (
+  contactId: number,
+  whatsappId: number
+): Promise<void> => {
   const ticket = await Ticket.findOne({
-    where: { contactId, status: { [Op.or]: ["open", "pending"] } }
+    where: { contactId, whatsappId, status: { [Op.or]: ["open", "pending"] } }
   });
 
   if (ticket) {

--- a/backend/src/helpers/GetDefaultWhatsApp.ts
+++ b/backend/src/helpers/GetDefaultWhatsApp.ts
@@ -1,7 +1,17 @@
 import AppError from "../errors/AppError";
 import Whatsapp from "../models/Whatsapp";
+import GetDefaultWhatsAppByUser from "./GetDefaultWhatsAppByUser";
 
-const GetDefaultWhatsApp = async (): Promise<Whatsapp> => {
+const GetDefaultWhatsApp = async (
+  userId?: number
+): Promise<Whatsapp> => {
+  if(userId) {
+    const whatsappByUser = await GetDefaultWhatsAppByUser(userId);
+    if(whatsappByUser !== null) {
+      return whatsappByUser;
+    }
+  }
+
   const defaultWhatsapp = await Whatsapp.findOne({
     where: { isDefault: true }
   });

--- a/backend/src/helpers/GetDefaultWhatsAppByUser.ts
+++ b/backend/src/helpers/GetDefaultWhatsAppByUser.ts
@@ -1,0 +1,18 @@
+import User from "../models/User";
+import Whatsapp from "../models/Whatsapp";
+import { logger } from "../utils/logger";
+
+const GetDefaultWhatsAppByUser = async (
+  userId: number
+): Promise<Whatsapp | null> => {
+  const user = await User.findByPk(userId, {include: ["whatsapp"]});
+  if( user === null ) {
+    return null;
+  }
+
+  logger.info(`Found whatsapp linked to user '${user.name}' is '${user.whatsapp.name}'.`);
+
+  return user.whatsapp;
+};
+
+export default GetDefaultWhatsAppByUser;

--- a/backend/src/helpers/GetDefaultWhatsAppByUser.ts
+++ b/backend/src/helpers/GetDefaultWhatsAppByUser.ts
@@ -10,7 +10,9 @@ const GetDefaultWhatsAppByUser = async (
     return null;
   }
 
-  logger.info(`Found whatsapp linked to user '${user.name}' is '${user.whatsapp.name}'.`);
+  if(user.whatsapp !== null) {
+    logger.info(`Found whatsapp linked to user '${user.name}' is '${user.whatsapp.name}'.`);
+  }
 
   return user.whatsapp;
 };

--- a/backend/src/helpers/GetTicketWbot.ts
+++ b/backend/src/helpers/GetTicketWbot.ts
@@ -5,7 +5,7 @@ import Ticket from "../models/Ticket";
 
 const GetTicketWbot = async (ticket: Ticket): Promise<Session> => {
   if (!ticket.whatsappId) {
-    const defaultWhatsapp = await GetDefaultWhatsApp();
+    const defaultWhatsapp = await GetDefaultWhatsApp(ticket.user.id);
 
     await ticket.$set("whatsapp", defaultWhatsapp);
   }

--- a/backend/src/helpers/SerializeUser.ts
+++ b/backend/src/helpers/SerializeUser.ts
@@ -1,5 +1,6 @@
 import Queue from "../models/Queue";
 import User from "../models/User";
+import Whatsapp from "../models/Whatsapp";
 
 interface SerializedUser {
   id: number;
@@ -7,6 +8,7 @@ interface SerializedUser {
   email: string;
   profile: string;
   queues: Queue[];
+  whatsapp: Whatsapp;
 }
 
 export const SerializeUser = (user: User): SerializedUser => {
@@ -15,6 +17,7 @@ export const SerializeUser = (user: User): SerializedUser => {
     name: user.name,
     email: user.email,
     profile: user.profile,
-    queues: user.queues
+    queues: user.queues,
+    whatsapp: user.whatsapp
   };
 };

--- a/backend/src/models/User.ts
+++ b/backend/src/models/User.ts
@@ -11,12 +11,15 @@ import {
   AutoIncrement,
   Default,
   HasMany,
-  BelongsToMany
+  BelongsToMany,
+  ForeignKey,
+  BelongsTo
 } from "sequelize-typescript";
 import { hash, compare } from "bcryptjs";
 import Ticket from "./Ticket";
 import Queue from "./Queue";
 import UserQueue from "./UserQueue";
+import Whatsapp from "./Whatsapp";
 
 @Table
 class User extends Model<User> {
@@ -44,6 +47,13 @@ class User extends Model<User> {
   @Default("admin")
   @Column
   profile: string;
+
+  @ForeignKey(() => Whatsapp)
+  @Column
+  whatsappId: number;
+
+  @BelongsTo(() => Whatsapp)
+  whatsapp: Whatsapp;
 
   @CreatedAt
   createdAt: Date;

--- a/backend/src/services/TicketServices/CreateTicketService.ts
+++ b/backend/src/services/TicketServices/CreateTicketService.ts
@@ -15,7 +15,7 @@ const CreateTicketService = async ({
   status,
   userId
 }: Request): Promise<Ticket> => {
-  const defaultWhatsapp = await GetDefaultWhatsApp();
+  const defaultWhatsapp = await GetDefaultWhatsApp(userId);
 
   await CheckContactOpenTickets(contactId);
 

--- a/backend/src/services/TicketServices/CreateTicketService.ts
+++ b/backend/src/services/TicketServices/CreateTicketService.ts
@@ -17,7 +17,7 @@ const CreateTicketService = async ({
 }: Request): Promise<Ticket> => {
   const defaultWhatsapp = await GetDefaultWhatsApp(userId);
 
-  await CheckContactOpenTickets(contactId);
+  await CheckContactOpenTickets(contactId, defaultWhatsapp.id);
 
   const { isGroup } = await ShowContactService(contactId);
 

--- a/backend/src/services/TicketServices/CreateTicketService.ts
+++ b/backend/src/services/TicketServices/CreateTicketService.ts
@@ -2,18 +2,21 @@ import AppError from "../../errors/AppError";
 import CheckContactOpenTickets from "../../helpers/CheckContactOpenTickets";
 import GetDefaultWhatsApp from "../../helpers/GetDefaultWhatsApp";
 import Ticket from "../../models/Ticket";
+import User from "../../models/User";
 import ShowContactService from "../ContactServices/ShowContactService";
 
 interface Request {
   contactId: number;
   status: string;
   userId: number;
+  queueId ?: number;
 }
 
 const CreateTicketService = async ({
   contactId,
   status,
-  userId
+  userId,
+  queueId
 }: Request): Promise<Ticket> => {
   const defaultWhatsapp = await GetDefaultWhatsApp(userId);
 
@@ -21,11 +24,17 @@ const CreateTicketService = async ({
 
   const { isGroup } = await ShowContactService(contactId);
 
+  if(queueId === undefined) {
+    const user = await User.findByPk(userId, { include: ["queues"]});
+    queueId = user?.queues.length === 1 ? user.queues[0].id : undefined;
+  }
+
   const { id }: Ticket = await defaultWhatsapp.$create("ticket", {
     contactId,
     status,
     isGroup,
-    userId
+    userId,
+    queueId
   });
 
   const ticket = await Ticket.findByPk(id, { include: ["contact"] });

--- a/backend/src/services/TicketServices/FindOrCreateTicketService.ts
+++ b/backend/src/services/TicketServices/FindOrCreateTicketService.ts
@@ -15,7 +15,8 @@ const FindOrCreateTicketService = async (
       status: {
         [Op.or]: ["open", "pending"]
       },
-      contactId: groupContact ? groupContact.id : contact.id
+      contactId: groupContact ? groupContact.id : contact.id,
+      whatsappId: whatsappId
     }
   });
 
@@ -26,7 +27,8 @@ const FindOrCreateTicketService = async (
   if (!ticket && groupContact) {
     ticket = await Ticket.findOne({
       where: {
-        contactId: groupContact.id
+        contactId: groupContact.id,
+        whatsappId: whatsappId
       },
       order: [["updatedAt", "DESC"]]
     });
@@ -46,7 +48,8 @@ const FindOrCreateTicketService = async (
         updatedAt: {
           [Op.between]: [+subHours(new Date(), 2), +new Date()]
         },
-        contactId: contact.id
+        contactId: contact.id,
+        whatsappId: whatsappId
       },
       order: [["updatedAt", "DESC"]]
     });

--- a/backend/src/services/TicketServices/ListTicketsService.ts
+++ b/backend/src/services/TicketServices/ListTicketsService.ts
@@ -6,6 +6,7 @@ import Contact from "../../models/Contact";
 import Message from "../../models/Message";
 import Queue from "../../models/Queue";
 import ShowUserService from "../UserServices/ShowUserService";
+import Whatsapp from "../../models/Whatsapp";
 
 interface Request {
   searchParam?: string;
@@ -50,6 +51,11 @@ const ListTicketsService = async ({
       model: Queue,
       as: "queue",
       attributes: ["id", "name", "color"]
+    },
+    {
+      model: Whatsapp,
+      as: "whatsapp",
+      attributes: ["name"]
     }
   ];
 

--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -33,6 +33,10 @@ const UpdateTicketService = async ({
   const ticket = await ShowTicketService(ticketId);
   await SetTicketMessagesAsRead(ticket);
 
+  if(whatsappId && ticket.whatsappId !== whatsappId) {
+    await CheckContactOpenTickets(ticket.contactId, whatsappId);
+  }
+
   const oldStatus = ticket.status;
   const oldUserId = ticket.user?.id;
 

--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -10,6 +10,7 @@ interface TicketData {
   status?: string;
   userId?: number;
   queueId?: number;
+  whatsappId?: number;
 }
 
 interface Request {
@@ -27,7 +28,7 @@ const UpdateTicketService = async ({
   ticketData,
   ticketId
 }: Request): Promise<Response> => {
-  const { status, userId, queueId } = ticketData;
+  const { status, userId, queueId, whatsappId } = ticketData;
 
   const ticket = await ShowTicketService(ticketId);
   await SetTicketMessagesAsRead(ticket);
@@ -46,6 +47,11 @@ const UpdateTicketService = async ({
   });
 
 
+  if(whatsappId) {
+    await ticket.update({
+      whatsappId
+    });
+  }
 
   await ticket.reload();
 

--- a/backend/src/services/TicketServices/UpdateTicketService.ts
+++ b/backend/src/services/TicketServices/UpdateTicketService.ts
@@ -36,7 +36,7 @@ const UpdateTicketService = async ({
   const oldUserId = ticket.user?.id;
 
   if (oldStatus === "closed") {
-    await CheckContactOpenTickets(ticket.contact.id);
+    await CheckContactOpenTickets(ticket.contact.id, ticket.whatsappId);
   }
 
   await ticket.update({

--- a/backend/src/services/UserServices/CreateUserService.ts
+++ b/backend/src/services/UserServices/CreateUserService.ts
@@ -68,9 +68,7 @@ const CreateUserService = async ({
 
   await user.reload();
 
-  const serializedUser = SerializeUser(user);
-
-  return serializedUser;
+  return SerializeUser(user);
 };
 
 export default CreateUserService;

--- a/backend/src/services/UserServices/CreateUserService.ts
+++ b/backend/src/services/UserServices/CreateUserService.ts
@@ -10,6 +10,7 @@ interface Request {
   name: string;
   queueIds?: number[];
   profile?: string;
+  whatsappId?: number;
 }
 
 interface Response {
@@ -24,7 +25,8 @@ const CreateUserService = async ({
   password,
   name,
   queueIds = [],
-  profile = "admin"
+  profile = "admin",
+  whatsappId
 }: Request): Promise<Response> => {
   const schema = Yup.object().shape({
     name: Yup.string().required().min(2),
@@ -56,9 +58,10 @@ const CreateUserService = async ({
       email,
       password,
       name,
-      profile
+      profile,
+      whatsappId: whatsappId ? whatsappId : null
     },
-    { include: ["queues"] }
+    { include: ["queues", "whatsapp"] }
   );
 
   await user.$set("queues", queueIds);

--- a/backend/src/services/UserServices/ListUsersService.ts
+++ b/backend/src/services/UserServices/ListUsersService.ts
@@ -1,6 +1,7 @@
 import { Sequelize, Op } from "sequelize";
 import Queue from "../../models/Queue";
 import User from "../../models/User";
+import Whatsapp from "../../models/Whatsapp";
 
 interface Request {
   searchParam?: string;
@@ -39,7 +40,8 @@ const ListUsersService = async ({
     offset,
     order: [["createdAt", "DESC"]],
     include: [
-      { model: Queue, as: "queues", attributes: ["id", "name", "color"] }
+      { model: Queue, as: "queues", attributes: ["id", "name", "color"] },
+      { model: Whatsapp, as: "whatsapp", attributes: ["id", "name"] },
     ]
   });
 

--- a/backend/src/services/UserServices/ShowUserService.ts
+++ b/backend/src/services/UserServices/ShowUserService.ts
@@ -1,12 +1,14 @@
 import User from "../../models/User";
 import AppError from "../../errors/AppError";
 import Queue from "../../models/Queue";
+import Whatsapp from "../../models/Whatsapp";
 
 const ShowUserService = async (id: string | number): Promise<User> => {
   const user = await User.findByPk(id, {
-    attributes: ["name", "id", "email", "profile", "tokenVersion"],
+    attributes: ["name", "id", "email", "profile", "tokenVersion", "whatsappId"],
     include: [
-      { model: Queue, as: "queues", attributes: ["id", "name", "color"] }
+      { model: Queue, as: "queues", attributes: ["id", "name", "color"] },
+      { model: Whatsapp, as: "whatsapp", attributes: ["id", "name"] },
     ],
     order: [ [ {  model: Queue, as: "queues"}, 'name', 'asc' ] ]
   });

--- a/backend/src/services/UserServices/UpdateUserService.ts
+++ b/backend/src/services/UserServices/UpdateUserService.ts
@@ -1,6 +1,7 @@
 import * as Yup from "yup";
 
 import AppError from "../../errors/AppError";
+import { SerializeUser } from "../../helpers/SerializeUser";
 import ShowUserService from "./ShowUserService";
 
 interface UserData {
@@ -9,6 +10,7 @@ interface UserData {
   name?: string;
   profile?: string;
   queueIds?: number[];
+  whatsappId?: number;
 }
 
 interface Request {
@@ -36,7 +38,7 @@ const UpdateUserService = async ({
     password: Yup.string()
   });
 
-  const { email, password, profile, name, queueIds = [] } = userData;
+  const { email, password, profile, name, queueIds = [], whatsappId } = userData;
 
   try {
     await schema.validate({ email, password, profile, name });
@@ -48,20 +50,15 @@ const UpdateUserService = async ({
     email,
     password,
     profile,
-    name
+    name,
+    whatsappId: whatsappId ? whatsappId : null
   });
 
   await user.$set("queues", queueIds);
 
   await user.reload();
 
-  const serializedUser = {
-    id: user.id,
-    name: user.name,
-    email: user.email,
-    profile: user.profile,
-    queues: user.queues
-  };
+  const serializedUser = SerializeUser(user);
 
   return serializedUser;
 };

--- a/backend/src/services/UserServices/UpdateUserService.ts
+++ b/backend/src/services/UserServices/UpdateUserService.ts
@@ -58,9 +58,7 @@ const UpdateUserService = async ({
 
   await user.reload();
 
-  const serializedUser = SerializeUser(user);
-
-  return serializedUser;
+  return SerializeUser(user);
 };
 
 export default UpdateUserService;

--- a/backend/src/services/WbotServices/ImportContactsService.ts
+++ b/backend/src/services/WbotServices/ImportContactsService.ts
@@ -3,8 +3,8 @@ import { getWbot } from "../../libs/wbot";
 import Contact from "../../models/Contact";
 import { logger } from "../../utils/logger";
 
-const ImportContactsService = async (): Promise<void> => {
-  const defaultWhatsapp = await GetDefaultWhatsApp();
+const ImportContactsService = async (userId:number): Promise<void> => {
+  const defaultWhatsapp = await GetDefaultWhatsApp(userId);
 
   const wbot = getWbot(defaultWhatsapp.id);
 

--- a/frontend/src/components/TicketListItem/index.js
+++ b/frontend/src/components/TicketListItem/index.js
@@ -99,6 +99,21 @@ const useStyles = makeStyles(theme => ({
 		top: "0%",
 		left: "0%",
 	},
+
+	userTag: {
+		position: "absolute",
+		marginRight: 5,
+		right: 5,
+		bottom: 5,
+		background:"#2576D2",
+		color: "#ffffff",
+		border:"1px solid #CCC",
+		padding: 1,
+		paddingLeft: 5,
+		paddingRight: 5,
+		borderRadius: 10,
+		fontSize: "1em"
+	},
 }));
 
 const TicketListItem = ({ ticket }) => {
@@ -195,6 +210,9 @@ const TicketListItem = ({ ticket }) => {
 										<>{format(parseISO(ticket.updatedAt), "dd/MM/yyyy")}</>
 									)}
 								</Typography>
+							)}
+							{ticket.whatsappId && (
+								<div className={classes.userTag} title={i18n.t("ticketsList.connectionTitle")}>{ticket.whatsapp.name}</div>
 							)}
 						</span>
 					}

--- a/frontend/src/components/TicketOptionsMenu/index.js
+++ b/frontend/src/components/TicketOptionsMenu/index.js
@@ -94,6 +94,7 @@ const TicketOptionsMenu = ({ ticket, menuOpen, handleClose, anchorEl }) => {
 				modalOpen={transferTicketModalOpen}
 				onClose={handleCloseTransferTicketModal}
 				ticketid={ticket.id}
+				ticketWhatsappId={ticket.whatsappId}
 			/>
 		</>
 	);

--- a/frontend/src/components/TransferTicketModal/index.js
+++ b/frontend/src/components/TransferTicketModal/index.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import { useHistory } from "react-router-dom";
 
 import Button from "@material-ui/core/Button";
@@ -23,6 +23,9 @@ import api from "../../services/api";
 import ButtonWithSpinner from "../ButtonWithSpinner";
 import toastError from "../../errors/toastError";
 import useQueues from "../../hooks/useQueues";
+import useWhatsApps from "../../hooks/useWhatsApps";
+import { AuthContext } from "../../context/Auth/AuthContext";
+import { Can } from "../Can";
 
 const useStyles = makeStyles((theme) => ({
   maxWidth: {
@@ -34,7 +37,7 @@ const filterOptions = createFilterOptions({
 	trim: true,
 });
 
-const TransferTicketModal = ({ modalOpen, onClose, ticketid }) => {
+const TransferTicketModal = ({ modalOpen, onClose, ticketid, ticketWhatsappId }) => {
 	const history = useHistory();
 	const [options, setOptions] = useState([]);
 	const [queues, setQueues] = useState([]);
@@ -43,8 +46,12 @@ const TransferTicketModal = ({ modalOpen, onClose, ticketid }) => {
 	const [searchParam, setSearchParam] = useState("");
 	const [selectedUser, setSelectedUser] = useState(null);
 	const [selectedQueue, setSelectedQueue] = useState('');
+	const [selectedWhatsapp, setSelectedWhatsapp] = useState(ticketWhatsappId);
 	const classes = useStyles();
 	const { findAll: findAllQueues } = useQueues();
+	const { loadingWhatsapps, whatsApps } = useWhatsApps();
+
+	const { user: loggedInUser } = useContext(AuthContext);
 
 	useEffect(() => {
 		const loadQueues = async () => {
@@ -105,6 +112,10 @@ const TransferTicketModal = ({ modalOpen, onClose, ticketid }) => {
 					data.status = 'pending';
 					data.userId = null;
 				}
+			}
+
+			if(selectedWhatsapp) {
+				data.whatsappId = selectedWhatsapp;
 			}
 
 			await api.put(`/tickets/${ticketid}`, data);
@@ -177,6 +188,24 @@ const TransferTicketModal = ({ modalOpen, onClose, ticketid }) => {
 							))}
 						</Select>
 					</FormControl>
+					<Can
+						role={loggedInUser.profile}
+						perform="ticket-options:transferWhatsapp"
+						yes={() => (!loadingWhatsapps && 
+							<FormControl variant="outlined" className={classes.maxWidth} style={{ marginTop: 20 }}>
+								<InputLabel>{i18n.t("transferTicketModal.fieldConnectionLabel")}</InputLabel>
+								<Select
+									value={selectedWhatsapp}
+									onChange={(e) => setSelectedWhatsapp(e.target.value)}
+									label={i18n.t("transferTicketModal.fieldConnectionPlaceholder")}
+								>
+									{whatsApps.map((whasapp) => (
+										<MenuItem key={whasapp.id} value={whasapp.id}>{whasapp.name}</MenuItem>
+									))}
+								</Select>
+							</FormControl>
+						)}
+					/>
 				</DialogContent>
 				<DialogActions>
 					<Button

--- a/frontend/src/components/UserModal/index.js
+++ b/frontend/src/components/UserModal/index.js
@@ -32,6 +32,7 @@ import toastError from "../../errors/toastError";
 import QueueSelect from "../QueueSelect";
 import { AuthContext } from "../../context/Auth/AuthContext";
 import { Can } from "../Can";
+import useWhatsApps from "../../hooks/useWhatsApps";
 
 const useStyles = makeStyles(theme => ({
 	root: {
@@ -79,7 +80,7 @@ const UserModal = ({ open, onClose, userId }) => {
 		name: "",
 		email: "",
 		password: "",
-		profile: "user",
+		profile: "user"
 	};
 
 	const { user: loggedInUser } = useContext(AuthContext);
@@ -87,7 +88,8 @@ const UserModal = ({ open, onClose, userId }) => {
 	const [user, setUser] = useState(initialState);
 	const [selectedQueueIds, setSelectedQueueIds] = useState([]);
 	const [showPassword, setShowPassword] = useState(false);
-
+	const [whatsappId, setWhatsappId] = useState(false);
+	const {loading, whatsApps} = useWhatsApps();
 
 	useEffect(() => {
 		const fetchUser = async () => {
@@ -99,6 +101,7 @@ const UserModal = ({ open, onClose, userId }) => {
 				});
 				const userQueueIds = data.queues?.map(queue => queue.id);
 				setSelectedQueueIds(userQueueIds);
+				setWhatsappId(data.whatsappId ? data.whatsappId : '');
 			} catch (err) {
 				toastError(err);
 			}
@@ -113,7 +116,7 @@ const UserModal = ({ open, onClose, userId }) => {
 	};
 
 	const handleSaveUser = async values => {
-		const userData = { ...values, queueIds: selectedQueueIds };
+		const userData = { ...values, whatsappId, queueIds: selectedQueueIds };
 		try {
 			if (userId) {
 				await api.put(`/users/${userId}`, userData);
@@ -240,6 +243,26 @@ const UserModal = ({ open, onClose, userId }) => {
 											selectedQueueIds={selectedQueueIds}
 											onChange={values => setSelectedQueueIds(values)}
 										/>
+									)}
+								/>
+								<Can
+									role={loggedInUser.profile}
+									perform="user-modal:editQueues"
+									yes={() => (
+										<FormControl variant="outlined" margin="dense" className={classes.maxWidth} fullWidth>
+											<InputLabel>{i18n.t("userModal.form.whatsapp")}</InputLabel>
+											<Field
+												as={Select}
+												value={whatsappId}
+												onChange={(e) => setWhatsappId(e.target.value)}
+												label={i18n.t("userModal.form.whatsapp")}
+											>
+												<MenuItem value={''}>&nbsp;</MenuItem>
+												{whatsApps.map((whatsapp) => (
+													<MenuItem key={whatsapp.id} value={whatsapp.id}>{whatsapp.name}</MenuItem>
+												))}
+											</Field>
+										</FormControl>
 									)}
 								/>
 							</DialogContent>

--- a/frontend/src/components/UserModal/index.js
+++ b/frontend/src/components/UserModal/index.js
@@ -248,7 +248,7 @@ const UserModal = ({ open, onClose, userId }) => {
 								<Can
 									role={loggedInUser.profile}
 									perform="user-modal:editQueues"
-									yes={() => (
+									yes={() => (!loading &&
 										<FormControl variant="outlined" margin="dense" className={classes.maxWidth} fullWidth>
 											<InputLabel>{i18n.t("userModal.form.whatsapp")}</InputLabel>
 											<Field

--- a/frontend/src/pages/Users/index.js
+++ b/frontend/src/pages/Users/index.js
@@ -244,6 +244,9 @@ const Users = () => {
                 {i18n.t("users.table.profile")}
               </TableCell>
               <TableCell align="center">
+                {i18n.t("users.table.whatsapp")}
+              </TableCell>              
+              <TableCell align="center">
                 {i18n.t("users.table.actions")}
               </TableCell>
             </TableRow>
@@ -255,6 +258,7 @@ const Users = () => {
                   <TableCell align="center">{user.name}</TableCell>
                   <TableCell align="center">{user.email}</TableCell>
                   <TableCell align="center">{user.profile}</TableCell>
+                  <TableCell align="center">{user.whatsapp?.name}</TableCell>
                   <TableCell align="center">
                     <IconButton
                       size="small"

--- a/frontend/src/rules.js
+++ b/frontend/src/rules.js
@@ -10,6 +10,7 @@ const rules = {
 			"user-modal:editProfile",
 			"user-modal:editQueues",
 			"ticket-options:deleteTicket",
+			"ticket-options:transferWhatsapp",
 			"contacts-page:deleteContact",
 		],
 	},

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -206,6 +206,7 @@ const messages = {
           email: "Email",
           password: "Password",
           profile: "Profile",
+          whatsapp: "Default Connection",
         },
         buttons: {
           okAdd: "Add",
@@ -340,6 +341,7 @@ const messages = {
           name: "Name",
           email: "Email",
           profile: "Profile",
+          whatsapp: "Default Connection",
           actions: "Actions",
         },
         buttons: {

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -263,6 +263,7 @@ const messages = {
         assignedHeader: "Working on",
         noTicketsTitle: "Nothing here!",
         noTicketsMessage: "No tickets found with this status or search term.",
+        connectionTitle: "Connection that is currently being used.",
         buttons: {
           accept: "Accept",
         },

--- a/frontend/src/translate/languages/en.js
+++ b/frontend/src/translate/languages/en.js
@@ -249,7 +249,9 @@ const messages = {
         title: "Transfer Ticket",
         fieldLabel: "Type to search for users",
         fieldQueueLabel: "Transfer to queue",
+        fieldConnectionLabel: "Transfer to connection",
         fieldQueuePlaceholder: "Please select a queue",
+        fieldConnectionPlaceholder: "Please select a connection",
         noOptions: "No user found with this name",
         buttons: {
           ok: "Transfer",

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -209,6 +209,7 @@ const messages = {
           email: "Correo Electrónico",
           password: "Contraseña",
           profile: "Perfil",
+          whatsapp: "Conexión estándar",
         },
         buttons: {
           okAdd: "Agregar",
@@ -345,6 +346,7 @@ const messages = {
           name: "Nombre",
           email: "Correo Electrónico",
           profile: "Perfil",
+          whatsapp: "Conexión estándar",
           actions: "Acciones",
         },
         buttons: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -265,6 +265,7 @@ const messages = {
         pendingHeader: "Cola",
         assignedHeader: "Trabajando en",
         noTicketsTitle: "¡Nada acá!",
+        connectionTitle: "Conexión que se está utilizando actualmente.",
         noTicketsMessage:
           "No se encontraron tickets con este estado o término de búsqueda",
         buttons: {

--- a/frontend/src/translate/languages/es.js
+++ b/frontend/src/translate/languages/es.js
@@ -252,7 +252,9 @@ const messages = {
         title: "Transferir Ticket",
         fieldLabel: "Escriba para buscar usuarios",
         fieldQueueLabel: "Transferir a la cola",
+        fieldConnectionLabel: "Transferir to conexión",
         fieldQueuePlaceholder: "Seleccione una cola",
+        fieldConnectionPlaceholder: "Seleccione una conexión",
         noOptions: "No se encontraron usuarios con ese nombre",
         buttons: {
           ok: "Transferir",

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -266,6 +266,7 @@ const messages = {
         noTicketsTitle: "Nada aqui!",
         noTicketsMessage:
           "Nenhum ticket encontrado com esse status ou termo pesquisado",
+        connectionTitle: "Conexão que está sendo utilizada atualmente.",
         buttons: {
           accept: "Aceitar",
         },

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -208,6 +208,7 @@ const messages = {
           email: "Email",
           password: "Senha",
           profile: "Perfil",
+          whatsapp: "Conexão Padrão",
         },
         buttons: {
           okAdd: "Adicionar",
@@ -344,6 +345,7 @@ const messages = {
           name: "Nome",
           email: "Email",
           profile: "Perfil",
+          whatsapp: "Conexão Padrão",
           actions: "Ações",
         },
         buttons: {

--- a/frontend/src/translate/languages/pt.js
+++ b/frontend/src/translate/languages/pt.js
@@ -251,7 +251,9 @@ const messages = {
         title: "Transferir Ticket",
         fieldLabel: "Digite para buscar usuários",
         fieldQueueLabel: "Transferir para fila",
+        fieldConnectionLabel: "Transferir para conexão",
         fieldQueuePlaceholder: "Selecione uma fila",
+        fieldConnectionPlaceholder: "Selecione uma conexão",
         noOptions: "Nenhum usuário encontrado com esse nome",
         buttons: {
           ok: "Transferir",


### PR DESCRIPTION
# Problema a ser resolvido

Adicionei meus números atuais no whaticket (tres no total), só que estou tendo alguns problemas. Quando o mesmo cliente vem falar com dois whatsapp (suporte e financeiro, aconteceu kkk) ele junta no mesmo chamado, dai como ele mandou mensagem primeiro pro suporte, quando o financeiro responde logicamente ele responde pelo whatsapp dele, dai pro cliente ele manda mensagem pro whatsapp do financeiro e a resposta vai pelo suporte, dá até um nó na cabeça. O segundo problema é quando você origina a mensagem manda sempre com o whatsapp padrão, dai se o financeiro faz (aqui o padrão deixei do suporte) ele manda pelo numero do suporte.

Segue as minhas sugestões que foram implementadas:

- [x] Criar migrações no banco de dados.
- [x] Usando whatsapp padrão definido por usuário.
- [x] Abrir mais de um ticket por usuário desde que seja usando outro whatsapp.
- [x] Atualizar whatsapp do ticket.
- [x] Quando iniciar ticket definir fila automaticamente se o usuário estiver somente um uma vinculada.
- [x] No cadastro de usuário adicionar campo whatsapp padrão.
- [x] Na modal de transferir também ter a opção de transferir para outro whatsapp.

Ontem mandei no grupo do discord sobre meu problema, ainda falta algumas coisas que planejei fazer.