### PR TITLE
Evitar erro na propriedade 'justify' e quando o 'ticket.whatsapp.name' for null

### DIFF
--- a/frontend/src/components/TicketListItem/index.js
+++ b/frontend/src/components/TicketListItem/index.js
@@ -105,9 +105,9 @@ const useStyles = makeStyles(theme => ({
 		marginRight: 5,
 		right: 5,
 		bottom: 5,
-		background:"#2576D2",
+		background: "#2576D2",
 		color: "#ffffff",
-		border:"1px solid #CCC",
+		border: "1px solid #CCC",
 		padding: 1,
 		paddingLeft: 5,
 		paddingRight: 5,
@@ -212,7 +212,7 @@ const TicketListItem = ({ ticket }) => {
 								</Typography>
 							)}
 							{ticket.whatsappId && (
-								<div className={classes.userTag} title={i18n.t("ticketsList.connectionTitle")}>{ticket.whatsapp.name}</div>
+								<div className={classes.userTag} title={i18n.t("ticketsList.connectionTitle")}>{ticket.whatsapp?.name}</div>
 							)}
 						</span>
 					}

--- a/frontend/src/pages/Signup/index.js
+++ b/frontend/src/pages/Signup/index.js
@@ -18,10 +18,10 @@ import {
 	InputAdornment,
 	IconButton,
 	Link
-  } from '@material-ui/core';
-  
+} from '@material-ui/core';
+
 import { LockOutlined, Visibility, VisibilityOff } from '@material-ui/icons';
-  
+
 import { makeStyles } from "@material-ui/core/styles";
 
 import { i18n } from "../../translate/i18n";
@@ -155,16 +155,16 @@ const SignUp = () => {
 										label={i18n.t("signup.form.password")}
 										type={showPassword ? 'text' : 'password'}
 										InputProps={{
-										endAdornment: (
-											<InputAdornment position="end">
-											<IconButton
-												aria-label="toggle password visibility"
-												onClick={() => setShowPassword((e) => !e)}
-											>
-												{showPassword ? <VisibilityOff /> : <Visibility />}
-											</IconButton>
-											</InputAdornment>
-										)
+											endAdornment: (
+												<InputAdornment position="end">
+													<IconButton
+														aria-label="toggle password visibility"
+														onClick={() => setShowPassword((e) => !e)}
+													>
+														{showPassword ? <VisibilityOff /> : <Visibility />}
+													</IconButton>
+												</InputAdornment>
+											)
 										}}
 									/>
 								</Grid>
@@ -178,7 +178,7 @@ const SignUp = () => {
 							>
 								{i18n.t("signup.buttons.submit")}
 							</Button>
-							<Grid container justify="flex-end">
+							<Grid container justifyContent="flex-end">
 								<Grid item>
 									<Link
 										href="#"


### PR DESCRIPTION
Propriedade **justify** renomeada para **justifyContent** evitando erro na rota **Signup**
```jsx
<Grid container justify="flex-end">
```
 para
```jsx 
<Grid container justifyContent="flex-end">
```

Corrigido o erro que é acontece quando a propriedade **name** vem null  no **TicketListItem**
```jsx
<div className={classes.userTag} title={i18n.t("ticketsList.connectionTitle")}>{ticket.whatsapp.name}</div>
```
 para 
```jsx
<div className={classes.userTag} title={i18n.t("ticketsList.connectionTitle")}>{ticket.whatsapp?.name}</div>
```