### PR TITLE
Fix search

### DIFF
--- a/frontend/src/components/TicketsList/index.js
+++ b/frontend/src/components/TicketsList/index.js
@@ -179,12 +179,12 @@ const reducer = (state, action) => {
 			type: "LOAD_TICKETS",
 			payload: tickets,
 		});
-	}, [tickets, status, searchParam]);
+	}, [tickets]);
 
 	useEffect(() => {
 		const socket = openSocket();
 
-		const shouldUpdateTicket = ticket =>
+		const shouldUpdateTicket = ticket => !searchParam &&
 			(!ticket.userId || ticket.userId === user?.id || showAll) &&
 			(!ticket.queueId || selectedQueueIds.indexOf(ticket.queueId) > -1);
 
@@ -244,7 +244,7 @@ const reducer = (state, action) => {
 		return () => {
 			socket.disconnect();
 		};
-	}, [status, showAll, user, selectedQueueIds]);
+	}, [status, searchParam, showAll, user, selectedQueueIds]);
 
 	useEffect(() => {
     if (typeof updateCount === "function") {

--- a/frontend/src/components/TicketsList/index.js
+++ b/frontend/src/components/TicketsList/index.js
@@ -263,6 +263,7 @@ const reducer = (state, action) => {
 		const { scrollTop, scrollHeight, clientHeight } = e.currentTarget;
 
 		if (scrollHeight - (scrollTop + 100) < clientHeight) {
+			e.currentTarget.scrollTop = scrollTop - 100;
 			loadMore();
 		}
 	};

--- a/frontend/src/components/TicketsManager/index.js
+++ b/frontend/src/components/TicketsManager/index.js
@@ -118,6 +118,7 @@ const TicketsManager = () => {
   useEffect(() => {
     if (tab === "search") {
       searchInputRef.current.focus();
+      setSearchParam("");
     }
   }, [tab]);
 


### PR DESCRIPTION
Hi, I noticed the search function was a little off so here's the fix.

- When searching something it would bring everything first, and then when you search for something else it would bring the search of the previous search param.
- When a ticket was updated it would show up in the search tab together with the search results.
- When scrolling it would sometimes not bring everything because it would kind of ignore the next page, e.g instead of calling page 2 it would make the api request for page 3.