### PR TITLE
Melhorias Whaileys Provider

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -2,6 +2,10 @@
 # Supported providers: wwebjs, whaileys
 WHATSAPP_PROVIDER=wwebjs
 
+# Logging (silent, fatal, error, warn, info, debug, trace)
+LOG_LEVEL=info
+WHAILEYS_LOG_LEVEL=error
+
 # Chrome/Puppeteer Configuration
 CHROME_BIN=
 CHROME_WS=

--- a/backend/.eslintrc.json
+++ b/backend/.eslintrc.json
@@ -41,6 +41,16 @@
       }
     ]
   },
+  "overrides": [
+    {
+      "files": [
+        "src/**/*.ts"
+      ],
+      "rules": {
+        "camelcase": "off"
+      }
+    }
+  ],
   "settings": {
     "import/resolver": {
       "typescript": {}

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "https-proxy-agent": "^7.0.6",
     "ioredis": "^5.8.2",
     "jsonwebtoken": "^8.5.1",
+    "lru-cache": "^11.2.4",
     "multer": "^1.4.2",
     "mustache": "^4.2.0",
     "mysql2": "^2.2.5",

--- a/backend/package.json
+++ b/backend/package.json
@@ -18,6 +18,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@adiwajshing/keyed-db": "^0.2.4",
     "@hapi/boom": "^10.0.1",
     "@sentry/node": "^5.29.2",
     "@types/lodash": "^4.17.5",

--- a/backend/src/providers/WhatsApp/Implementations/whaileys.ts
+++ b/backend/src/providers/WhatsApp/Implementations/whaileys.ts
@@ -580,6 +580,21 @@ const convertToContactPayload = async (
     wbot.store?.chats?.get?.(resolvedJid) ||
     wbot.store?.chats?.get?.(normalizedJid);
 
+  let profilePicUrl: string | undefined;
+
+  if (normalizedJid) {
+    try {
+      const url = await wbot.profilePictureUrl(normalizedJid, "image");
+      profilePicUrl = url || undefined;
+    } catch (err) {
+      logger.debug({
+        info: "Could not get profile picture",
+        jid: normalizedJid,
+        err
+      });
+    }
+  }
+
   if (isJidGroup(resolvedJid)) {
     const groupNumber = normalizedJid.split("@")[0];
     const groupName =
@@ -597,7 +612,8 @@ const convertToContactPayload = async (
           return {
             name: metaName,
             number: groupNumber,
-            isGroup: true
+            isGroup: true,
+            profilePicUrl
           };
         }
       } catch {
@@ -608,7 +624,8 @@ const convertToContactPayload = async (
     return {
       name: groupName,
       number: groupNumber,
-      isGroup: true
+      isGroup: true,
+      profilePicUrl
     };
   }
 
@@ -634,7 +651,8 @@ const convertToContactPayload = async (
     name,
     number,
     lid: lidValue,
-    isGroup: false
+    isGroup: false,
+    profilePicUrl
   };
 };
 

--- a/backend/src/providers/WhatsApp/Implementations/whaileys.ts
+++ b/backend/src/providers/WhatsApp/Implementations/whaileys.ts
@@ -940,12 +940,12 @@ const init = async (whatsapp: Whatsapp): Promise<void> => {
           if (!key.id) return;
 
           let ack: MessageAck = 2;
-          if (receipt.receiptTimestamp) {
-            ack = 3;
+          if (receipt.playedTimestamp) {
+            ack = 4;
           } else if (receipt.readTimestamp) {
             ack = 3;
-          } else if (receipt.playedTimestamp) {
-            ack = 4;
+          } else if (receipt.receiptTimestamp) {
+            ack = 2;
           }
 
           await handleMessageAck(key.id, ack);
@@ -996,7 +996,7 @@ const sendMessage = async (
         text: body,
         contextInfo: {
           stanzaId: options.quotedMessageId,
-          participant: options.quotedMessageFromMe ? wbot.user?.id : to
+          participant: options.quotedMessageFromMe ? wbot.user?.id : toJid
         }
       }
     : { text: body };
@@ -1242,7 +1242,10 @@ const fetchChatMessages = async (
 ): Promise<ProviderMessage[]> => {
   const wbot = getWbot(sessionId);
 
-  const messagesFromStore = wbot.store?.messages?.[chatId]?.array || [];
+  const normalizedChatId = normalizeJid(chatId);
+
+  const messagesFromStore =
+    wbot.store?.messages?.[normalizedChatId]?.array || [];
 
   const messages = messagesFromStore.slice(-limit);
 
@@ -1254,7 +1257,7 @@ const fetchChatMessages = async (
     type: mapMessageType(msg),
     timestamp: msg.messageTimestamp ? Number(msg.messageTimestamp) : Date.now(),
     from: msg.key.participant || msg.key.remoteJid || "",
-    to: chatId,
+    to: normalizedChatId,
     ack: mapMessageAck(msg.status)
   }));
 };

--- a/backend/src/providers/WhatsApp/Implementations/whaileys.ts
+++ b/backend/src/providers/WhatsApp/Implementations/whaileys.ts
@@ -631,6 +631,15 @@ const convertToContactPayload = async (
 
   const decoded = jidDecode(resolvedJid);
 
+  const sessionPushName = wbot.user?.name?.trim().toLowerCase();
+  const incomingPushName = msg.pushName?.trim();
+  const pushName =
+    incomingPushName &&
+    sessionPushName &&
+    incomingPushName.toLowerCase() === sessionPushName
+      ? undefined
+      : incomingPushName;
+
   const number =
     (isJidUser(resolvedJid) && decoded?.user) ||
     jidDecode(preferPn || "")?.user ||
@@ -642,7 +651,7 @@ const convertToContactPayload = async (
   const name =
     contactInfo?.name ||
     contactInfo?.notify ||
-    msg.pushName ||
+    pushName ||
     number ||
     lidValue ||
     "";

--- a/backend/src/utils/logger.ts
+++ b/backend/src/utils/logger.ts
@@ -1,9 +1,27 @@
 import pino from "pino";
 
+type LogLevel =
+  | "fatal"
+  | "error"
+  | "warn"
+  | "info"
+  | "debug"
+  | "trace"
+  | "silent";
+
+const level = (process.env.LOG_LEVEL as LogLevel) || "info";
+
+const isProduction = process.env.NODE_ENV === "production";
+
 const logger = pino({
-  prettyPrint: {
-    ignore: "pid,hostname"
-  }
+  level,
+  prettyPrint: isProduction
+    ? false
+    : {
+        colorize: true,
+        ignore: "pid,hostname",
+        translateTime: "SYS:standard"
+      }
 });
 
 export { logger };


### PR DESCRIPTION
Resumo:
- Centralizado logging do provider whaileys com pino e ajustes no logger para ter flexivel quanto aos niveis.
- Adicionado cache de mensagens `lru-cache`, retry e gerenciamento de store/keyed-db para reduzir perdas e reprocessamentos no ciclo de mensagens.
- Implementado debounce e flush de salvamento de credenciais de sessão, evitando gravações excessivas e estados corrompidos.
- Normalizado IDs/JIDs e mapeamento de ack, melhorando coerência em mensagens enviadas/recebidas (incluindo citação).
- Extendido o payload de contato com contexto extra (keys, participant, lid) e passa a buscar foto de perfil em grupos/contatos.
- Incluido regra ESLint de camelcase (por conta da extensão de contexto dos contacts).
- Dependência `keyed-db` adicionada para suportar store/cache interno.
- Atualizado .env.example com duas novas variaveis de logging `LOG_LEVEL` e `WHAILEYS_LOG_LEVEL`.
- Adicionado tratamento para pushName de grupos
- Adicionado limpeza das creds no redis para sessões desconectadas

Como testar:
1. `cd backend && npm install`
2. `npm run build`
3. Subir backend de produção e receber/enviar mensagens (incluindo respostas citadas e grupos) verificando logs e delivery/ack.
4. Conferir que contatos criados/atualizados trazem foto de perfil e dados de contexto corretos.

Notas:
- Retries e cache atuam apenas no provider whaileys.